### PR TITLE
Add zoneinfo.zip to allow running inside docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,13 @@ RUN go install
 
 FROM alpine:3.8
 
-COPY --from=build /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 COPY --from=build /go/bin/corrie /usr/local/corrie
 COPY etc /etc/
 
-RUN adduser -DH user
+RUN \
+  apk add --no-cache \
+    tzdata \
+  && adduser -DH user
 
 USER user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go install
 
 FROM alpine:3.8
 
+COPY --from=build /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 COPY --from=build /go/bin/corrie /usr/local/corrie
 COPY etc /etc/
 


### PR DESCRIPTION
Without this file, import of "time" inside the container fails. 